### PR TITLE
feat: Add moving object with looped trajectory

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
     <img id="skyTex" src="assets/images/sky.jpg" crossorigin="anonymous">
     <!-- сцена -->
     <a-asset-item id="world" src="assets/models/limassol-walk.glb"></a-asset-item>
+    <a-asset-item id="movingObject" src="assets/models/moving.glb"></a-asset-item>
 
     <!-- HUD-видео и общий мобильный видео-элемент для плейнов -->
     <video id="popupVideo" preload="metadata" playsinline webkit-playsinline crossorigin="anonymous"></video>
@@ -678,6 +679,7 @@ AFRAME.registerComponent('plane-video-once',{
     const popupTrigs=document.getElementsByClassName('trigger-popup');
     const revealTrigs=document.getElementsByClassName('trigger-reveal');
     const planeTrigs=document.getElementsByClassName('trigger-plane');
+    const movingTrigs=document.getElementsByClassName('trigger-moving');
 
     ctx.clearRect(0,0,c.width,c.height);
     ctx.lineWidth=1; ring(R,0.25); ring(R*0.66,0.18); ring(R*0.33,0.14);
@@ -710,6 +712,7 @@ AFRAME.registerComponent('plane-video-once',{
     draw(popupTrigs,'#ff69b4'); // розовый — HUD
     draw(revealTrigs,'#ffd400'); // жёлтый — спавн узлов
     draw(planeTrigs, '#65d0ff'); // голубой — плейны
+    draw(movingTrigs, '#0080FF'); // синий — движущийся объект
   }, INTERVAL);
 })();
 
@@ -725,6 +728,79 @@ AFRAME.registerComponent('clamp-rect',{
   }
 });
 document.querySelector('a-scene').setAttribute('clamp-rect','minX:-25; maxX:25; minZ:-10; maxZ:10');
+
+/* ========== moving object ========== */
+AFRAME.registerComponent('moving-object-trigger', {
+    schema: {
+        radius: { default: 1.0 },
+    },
+
+    init: function () {
+        this.movingObject = null;
+        this.triggered = false;
+
+        this.spawnPoint = new THREE.Vector3(-3.789, 0, 3.585);
+        this.waypoints = [
+            new THREE.Vector3(-16.632, 0, 4.002),
+            new THREE.Vector3(-17.379, 0, -0.914),
+            new THREE.Vector3(15.093, 0, -4.741),
+            new THREE.Vector3(15.820, 0, -0.646)
+        ];
+        this.speed = 1; // 1 meter per second
+        this.targetIndex = -1; // -1 means it's at spawn, and will move to waypoints[0]
+
+        const movingObjectEntity = document.createElement('a-entity');
+        movingObjectEntity.setAttribute('gltf-model', '#movingObject');
+        movingObjectEntity.object3D.visible = false;
+        this.el.sceneEl.appendChild(movingObjectEntity);
+        this.movingObject = movingObjectEntity;
+
+        this.movingObject.object3D.position.copy(this.spawnPoint);
+    },
+
+    tick: function (time, deltaTime) {
+        if (!this.movingObject) return;
+
+        if (!this.triggered) {
+            const playerPos = (isTouch ? rig : camEl).object3D.getWorldPosition(new THREE.Vector3());
+            const triggerPos = this.el.object3D.getWorldPosition(new THREE.Vector3());
+            const distance = playerPos.distanceTo(triggerPos);
+
+            if (distance <= this.data.radius) {
+                this.triggered = true;
+                this.movingObject.object3D.visible = true;
+                this.targetIndex = 0; // Start moving towards the first waypoint
+            }
+            return; // Don't move on the same frame it's triggered
+        }
+
+        this.move(deltaTime);
+    },
+
+    move: function (deltaTime) {
+        if (!this.movingObject || this.targetIndex === -1) return;
+
+        const targetPosition = this.waypoints[this.targetIndex];
+        const currentPosition = this.movingObject.object3D.position;
+        const distanceToTarget = currentPosition.distanceTo(targetPosition);
+
+        // When it's close enough to the target, switch to the next one
+        if (distanceToTarget < 0.1) {
+            // Rotate 90 degrees clockwise on Y axis
+            const yRotation = new THREE.Euler(0, -Math.PI / 2, 0);
+            this.movingObject.object3D.quaternion.multiply(new THREE.Quaternion().setFromEuler(yRotation));
+
+            // Move to the next waypoint in the loop
+            this.targetIndex = (this.targetIndex + 1) % this.waypoints.length;
+        }
+
+        // Move towards the current target
+        const nextTargetPosition = this.waypoints[this.targetIndex];
+        const direction = nextTargetPosition.clone().sub(currentPosition).normalize();
+        const moveDistance = this.speed * (deltaTime / 1000);
+        this.movingObject.object3D.position.add(direction.multiplyScalar(moveDistance));
+    }
+});
 
 /* ========== дирижёр триггеров ========== */
 AFRAME.registerComponent('trigger-director',{
@@ -768,6 +844,12 @@ AFRAME.registerComponent('trigger-director',{
           e.setAttribute('sound', `src:#${name}Audio; positional:true`);
         }
       });
+
+      const movingObjectTrigger = document.createElement('a-entity');
+      movingObjectTrigger.classList.add('trigger-moving');
+      movingObjectTrigger.setAttribute('position', '-2.862 1.6 3.478');
+      movingObjectTrigger.setAttribute('moving-object-trigger', '');
+      scene.appendChild(movingObjectTrigger);
     });
   }
 });


### PR DESCRIPTION
This commit introduces a new feature: a moving object that follows a predefined looped trajectory.

A new A-Frame component, `moving-object-trigger`, has been created to manage the object's behavior. The object (`moving.glb`) is spawned when the player enters a 1-meter radius of a specific trigger point. Once triggered, the object becomes permanently visible and continuously moves along a set path, rotating 90 degrees at each waypoint.

The trigger point has been added to the radar as a blue marker for visibility.

The implementation includes:
- A new A-Frame component for the moving object's logic.
- A one-time trigger based on player proximity.
- Looped movement along a specified trajectory at 1 m/s.
- 90-degree clockwise rotation at each waypoint.
- A blue marker on the radar for the trigger point.