### PR TITLE
fix: Ensure moving object animation plays correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,8 +753,12 @@ AFRAME.registerComponent('moving-object-trigger', {
         movingObjectEntity.setAttribute('gltf-model', '#movingObject');
         movingObjectEntity.setAttribute('scale', '0.4 0.4 0.4');
         movingObjectEntity.setAttribute('rotation', '0 -90 0');
-        movingObjectEntity.setAttribute('animation-mixer', 'clip: *; loop: repeat');
         movingObjectEntity.object3D.visible = false;
+
+        movingObjectEntity.addEventListener('model-loaded', () => {
+            movingObjectEntity.setAttribute('animation-mixer', 'clip: *; loop: repeat');
+        });
+
         this.el.sceneEl.appendChild(movingObjectEntity);
         this.movingObject = movingObjectEntity;
 


### PR DESCRIPTION
This commit fixes an issue where the animation for the moving object was not playing.

The `animation-mixer` was being initialized before the `gltf-model` was fully loaded, which caused the animation to fail silently.

The fix is to add an event listener for the `model-loaded` event on the moving object's entity. The `animation-mixer` is now initialized inside the callback of this event listener, which ensures that the model's animation clips are available before the animation is started.