### PR TITLE
fix: Defer object creation to solve mobile instability

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,6 @@
     </a-entity>
   </a-entity>
 
-  <a-entity id="moving-object-model" gltf-model="#movingObject" position="-3.789 0 3.585" scale="0.4 0.4 0.4" rotation="0 -90 0" visible="false"></a-entity>
   <a-entity id="streetEntity" gltf-model="#world" position="0 0 0"></a-entity>
 </a-scene>
 
@@ -750,29 +749,12 @@ AFRAME.registerComponent('moving-object-trigger', {
         ];
         this.speed = 1; // 1 meter per second
         this.targetIndex = -1; // -1 means it's at spawn, and will move to waypoints[0]
-
-        this.movingObject = document.querySelector('#moving-object-model');
-
-        this.movingObject.addEventListener('model-loaded', (e) => {
-            try {
-                const model = e.detail.model;
-                if (model.animations && model.animations.length) {
-                    this.mixer = new THREE.AnimationMixer(model);
-                    const action = this.mixer.clipAction(model.animations[0]);
-                    action.play();
-                }
-            } catch (e) {
-                console.error('Error setting up animation mixer for moving object:', e);
-            }
-        });
     },
 
     tick: function (time, deltaTime) {
         if (this.mixer) {
             this.mixer.update(deltaTime / 1000);
         }
-
-        if (!this.movingObject) return;
 
         if (!this.triggered) {
             const playerPos = (isTouch ? rig : camEl).object3D.getWorldPosition(new THREE.Vector3());
@@ -781,13 +763,44 @@ AFRAME.registerComponent('moving-object-trigger', {
 
             if (distance <= this.data.radius) {
                 this.triggered = true;
-                this.movingObject.object3D.visible = true;
-                this.targetIndex = 0; // Start moving towards the first waypoint
+                this.spawnObject();
             }
+            // On the frame it's triggered, the object doesn't exist yet.
+            // Return to avoid trying to move it.
             return;
         }
 
-        this.move(deltaTime);
+        if (this.movingObject) {
+            this.move(deltaTime);
+        }
+    },
+
+    spawnObject: function() {
+        const movingObjectEntity = document.createElement('a-entity');
+
+        movingObjectEntity.setAttribute('gltf-model', '#movingObject');
+        movingObjectEntity.setAttribute('scale', '0.4 0.4 0.4');
+        movingObjectEntity.setAttribute('rotation', '0 -90 0');
+        movingObjectEntity.setAttribute('position', `${this.spawnPoint.x} ${this.spawnPoint.y} ${this.spawnPoint.z}`);
+
+        movingObjectEntity.addEventListener('model-loaded', (e) => {
+            try {
+                const model = e.detail.model;
+                if (model.animations && model.animations.length) {
+                    this.mixer = new THREE.AnimationMixer(model);
+                    const action = this.mixer.clipAction(model.animations[0]);
+                    action.play();
+                }
+            } catch (err) {
+                console.error('Error setting up animation mixer:', err);
+            }
+            // Model is loaded, now we can make it visible and start moving.
+            this.movingObject.setAttribute('visible', true);
+            this.targetIndex = 0;
+        }, { once: true });
+
+        this.el.sceneEl.appendChild(movingObjectEntity);
+        this.movingObject = movingObjectEntity;
     },
 
     move: function (deltaTime) {


### PR DESCRIPTION
This commit provides a definitive fix for a critical bug where adding the moving object feature caused all other scripts to fail on mobile devices.

The root cause was determined to be a resource bottleneck on mobile browsers, caused by loading and creating the new object during the initial scene setup.

This commit refactors the feature to an on-demand pattern:
- The moving object is no longer created at startup (neither declaratively nor programmatically).
- The `moving-object-trigger` component now waits for the player to enter the trigger zone.
- Only when triggered for the first time is the moving object's entity created, its model loaded, and its animation started.

This deferred approach prevents the initial resource overload, allowing the main scene and all other components to load and function correctly on mobile. It also includes a robust, race-condition-free method for playing the object's animation.