### PR TITLE
test: Disable moving object logic for diagnostics

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,71 +738,15 @@ AFRAME.registerComponent('moving-object-logic', {
     },
 
     init: function () {
-        this.triggered = false;
-        this.mixer = null;
-        const spawnPoint = new THREE.Vector3(-3.789, 0, 3.585);
-        this.waypoints = [
-            new THREE.Vector3(-16.632, 0, 4.002),
-            new THREE.Vector3(-17.379, 0, -0.914),
-            new THREE.Vector3(15.093, 0, -4.741),
-            new THREE.Vector3(15.820, 0, -0.646)
-        ];
-        this.speed = 1;
-        this.targetIndex = -1;
-
-        this.el.object3D.position.copy(spawnPoint);
-        this.el.setAttribute('visible', false);
-
-        this.el.addEventListener('model-loaded', (e) => {
-            try {
-                const model = e.detail.model;
-                if (model.animations && model.animations.length) {
-                    this.mixer = new THREE.AnimationMixer(model);
-                    const action = this.mixer.clipAction(model.animations[0]);
-                    action.play();
-                }
-            } catch (err) {
-                console.error('Error setting up animation mixer:', err);
-            }
-        }, { once: true });
+        // DIAGNOSTIC: Component logic disabled
     },
 
     tick: function (time, deltaTime) {
-        if (this.mixer) {
-            this.mixer.update(deltaTime / 1000);
-        }
-
-        if (!this.triggered) {
-            const playerPos = (isTouch ? rig : camEl).object3D.getWorldPosition(new THREE.Vector3());
-            const distance = playerPos.distanceTo(this.data.triggerPosition);
-            if (distance <= this.data.radius) {
-                this.triggered = true;
-                this.el.setAttribute('visible', true);
-                this.targetIndex = 0;
-            }
-            return;
-        }
-
-        this.move(deltaTime);
+        // DIAGNOSTIC: Component logic disabled
     },
 
     move: function (deltaTime) {
-        if (this.targetIndex === -1) return;
-
-        const targetPosition = this.waypoints[this.targetIndex];
-        const currentPosition = this.el.object3D.position;
-        const distanceToTarget = currentPosition.distanceTo(targetPosition);
-
-        if (distanceToTarget < 0.1) {
-            const yRotation = new THREE.Euler(0, -Math.PI / 2, 0);
-            this.el.object3D.quaternion.multiply(new THREE.Quaternion().setFromEuler(yRotation));
-            this.targetIndex = (this.targetIndex + 1) % this.waypoints.length;
-        }
-
-        const nextTargetPosition = this.waypoints[this.targetIndex];
-        const direction = nextTargetPosition.clone().sub(currentPosition).normalize();
-        const moveDistance = this.speed * (deltaTime / 1000);
-        this.el.object3D.position.add(direction.multiplyScalar(moveDistance));
+        // DIAGNOSTIC: Component logic disabled
     }
 });
 


### PR DESCRIPTION
This is a temporary diagnostic commit to isolate the root cause of a critical bug where the application fails on mobile devices.

The hypothesis is that the code inside the
`moving-object-logic` component is causing the mobile browser to crash or stall.

To test this, all logic inside the `init`, `tick`, and `move` methods of the component has been commented out, making it completely inert. The moving object will not appear or move.

If the application's other triggers now work on mobile, it will prove that the problem lies within the disabled code. If it still fails, the problem is more fundamental, likely related to the A-Frame component system or entity count on mobile.