### PR TITLE
test: Remove throttle to diagnose trigger logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -755,8 +755,6 @@ AFRAME.registerComponent('moving-object-logic', {
         ];
         this.speed = 1;
         this.targetIndex = -1;
-        this.tickCounter = 0;
-        this.checkInterval = 10; // Check distance every 10 ticks
 
         this.el.object3D.position.copy(spawnPoint);
         this.el.setAttribute('visible', false);
@@ -781,15 +779,12 @@ AFRAME.registerComponent('moving-object-logic', {
         }
 
         if (!this.triggered) {
-            this.tickCounter++;
-            if (this.tickCounter % this.checkInterval === 0) {
-                const playerPos = (isTouch ? rig : camEl).object3D.getWorldPosition(new THREE.Vector3());
-                const distance = playerPos.distanceTo(this.data.triggerPosition);
-                if (distance <= this.data.radius) {
-                    this.triggered = true;
-                    this.el.setAttribute('visible', true);
-                    this.targetIndex = 0;
-                }
+            const playerPos = (isTouch ? rig : camEl).object3D.getWorldPosition(new THREE.Vector3());
+            const distance = playerPos.distanceTo(this.data.triggerPosition);
+            if (distance <= this.data.radius) {
+                this.triggered = true;
+                this.el.setAttribute('visible', true);
+                this.targetIndex = 0;
             }
             return;
         }


### PR DESCRIPTION
This is a temporary diagnostic commit to isolate the root cause of a critical bug on mobile devices.

The previous test showed the bug is in the component's JS code. The last change introduced a performance throttle to the `tick` function, which resulted in the object never appearing on mobile.

This commit removes the performance throttle. The distance check will now run on every frame.

The purpose of this test is to see if the object appears on mobile, even if the application's other triggers subsequently crash.
- If it appears, the throttle logic was flawed.
- If it does not appear, the distance check logic itself is flawed or is the source of the crash.