### PR TITLE
refactor: Implement event-driven proximity system for performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,8 @@
     <a-entity id="player" camera="near:0.01; far:1000"
               look-controls="touchEnabled:false; mouseEnabled:true"
               position="0 1.6 0"
-              cursor="rayOrigin: mouse" raycaster="objects: .clickable; far: 50">
+              cursor="rayOrigin: mouse" raycaster="objects: .clickable; far: 50"
+              proximity-checker>
     </a-entity>
   </a-entity>
 
@@ -388,15 +389,19 @@ let isMediaBusy = false;
 
 /* ========== HUD pop-up (мобилка без звука, но у cat — отдельная дорожка) ========== */
 AFRAME.registerComponent('popup-video-hud',{
-  schema:{ radius:{default:2.0}, loops:{default:1}, hysteresis:{default:0.10}, side:{default:'right'}, src:{default:'assets/video/clip1.mp4'}, audio:{default:''} },
-  init(){ this.active=false; this.waitExit=false; this.looped=0; this.video=popupHud; this._onEnded=this.onEnded.bind(this); },
-  tick(){
-    if (isTouch && isMediaBusy) return;
-    const m=(isTouch?rig:camEl).object3D.getWorldPosition(new THREE.Vector3());
-    const t=this.el.object3D.getWorldPosition(new THREE.Vector3());
-    const d=Math.hypot(m.x-t.x, m.z-t.z);
-    if (this.waitExit && d>(this.data.radius+this.data.hysteresis)) this.waitExit=false;
-    if (!this.active && !this.waitExit && d<=this.data.radius) this.show();
+  schema:{ loops:{default:1}, hysteresis:{default:0.10}, side:{default:'right'}, src:{default:'assets/video/clip1.mp4'}, audio:{default:''} },
+  init(){
+    this.active=false;
+    this.waitExit=false;
+    this.looped=0;
+    this.video=popupHud;
+    this._onEnded=this.onEnded.bind(this);
+    this.el.addEventListener('player-enter', () => {
+        if (!this.active && !this.waitExit) this.show();
+    });
+    this.el.addEventListener('player-leave', () => {
+        if (this.waitExit) this.waitExit = false;
+    });
   },
   async show(){
     if (!userMediaUnlocked){ const retry=()=>{ window.removeEventListener('touchstart', retry); this.show(); }; window.addEventListener('touchstart', retry, {once:true}); return; }
@@ -490,8 +495,15 @@ AFRAME.registerComponent('crumb-trail',{
 
 /* ========== gyros (reveal+звук) ========== */
 AFRAME.registerComponent('reveal-node-rot-fade',{
-  schema:{ targetName:{default:''}, radius:{default:2.0}, hysteresis:{default:0.20}, spinDegPerSec:{default:60}, lifeMs:{default:15000}, fadeMs:{default:800}, soundId:{default:'gyrosAudio'} },
-  init(){ this.armed=true; this.active=false; this.targetNode=null; this.spawnTime=0; this.fading=false; this.fadeStart=0; this.soundEnt=null;
+  schema:{ targetName:{default:''}, spinDegPerSec:{default:60}, lifeMs:{default:15000}, fadeMs:{default:800}, soundId:{default:'gyrosAudio'} },
+  init(){
+    this.armed=true;
+    this.active=false;
+    this.targetNode=null;
+    this.spawnTime=0;
+    this.fading=false;
+    this.fadeStart=0;
+    this.soundEnt=null;
     whenModelReady(root=>{
       this.targetNode=findNodeByName(root,this.data.targetName);
       if(!this.targetNode){ console.warn('Gyros node not found'); return; }
@@ -502,43 +514,50 @@ AFRAME.registerComponent('reveal-node-rot-fade',{
       s.setAttribute('sound',`src:#${this.data.soundId}; positional:true; refDistance:2; maxDistance:12; rolloffFactor:1`);
       streetEntity.sceneEl.appendChild(s); this.soundEnt=s;
     });
+    this.el.addEventListener('player-enter', () => {
+        if (this.armed && !this.active) this.trigger();
+    });
+    this.el.addEventListener('player-leave', () => {
+        if (!this.active) this.armed = true;
+    });
+  },
+  trigger() {
+    if (isTouch && isMediaBusy) return;
+    if (isTouch) isMediaBusy = true;
+    this.active=true; this.fading=false; this.fadeStart=0; this.spawnTime=this.el.sceneEl.time;
+    this.targetNode.visible=true; this.targetNode.scale.setScalar(1);
+    resumeSceneAudioContext();
+    try{ this.soundEnt?.components.sound.stopSound(); }catch(_){}
+    try{ this.soundEnt?.components.sound.playSound(); }catch(_){ setTimeout(()=>this.soundEnt?.components.sound.playSound(), 140); }
   },
   tick(time,dt){
-    if(!this.targetNode) return;
+    if(!this.targetNode || !this.active) return;
     const now=this.el.sceneEl.time;
-    const m=(isTouch?rig:camEl).object3D.getWorldPosition(new THREE.Vector3());
-    const t=this.el.object3D.getWorldPosition(new THREE.Vector3());
-    const d=Math.hypot(m.x-t.x, m.z-t.z);
-
-    if (this.armed && d<=this.data.radius && !this.active){
-      if (isTouch && isMediaBusy) return;
-      if (isTouch) isMediaBusy = true;
-      this.active=true; this.fading=false; this.fadeStart=0; this.spawnTime=now;
-      this.targetNode.visible=true; this.targetNode.scale.setScalar(1);
-      resumeSceneAudioContext();
-      try{ this.soundEnt?.components.sound.stopSound(); }catch(_){}
-      try{ this.soundEnt?.components.sound.playSound(); }catch(_){ setTimeout(()=>this.soundEnt?.components.sound.playSound(), 140); }
-    } else if (!this.armed && d>(this.data.radius+this.data.hysteresis) && !this.active){ this.armed=true; }
-
-    if (this.active){
-      const sec=Math.min(0.05, dt/1000);
-      this.targetNode.rotation.y += (this.data.spinDegPerSec*Math.PI/180)*sec;
-      if (!this.fading && (now - this.spawnTime) >= this.data.lifeMs){ this.fading=true; this.fadeStart=now; }
-      if (this.fading){
-        const t=(now - this.fadeStart)/this.data.fadeMs; const k=Math.min(1,Math.max(0,t)); const s=1-(k*k*(3-2*k));
-        this.targetNode.scale.setScalar(Math.max(0,s));
-        if (k>=1){
-          this.targetNode.visible=false; this.active=false; this.fading=false;
-          if (isTouch) isMediaBusy = false;
-        }
+    const sec=Math.min(0.05, dt/1000);
+    this.targetNode.rotation.y += (this.data.spinDegPerSec*Math.PI/180)*sec;
+    if (!this.fading && (now - this.spawnTime) >= this.data.lifeMs){ this.fading=true; this.fadeStart=now; }
+    if (this.fading){
+      const t=(now - this.fadeStart)/this.data.fadeMs; const k=Math.min(1,Math.max(0,t)); const s=1-(k*k*(3-2*k));
+      this.targetNode.scale.setScalar(Math.max(0,s));
+      if (k>=1){
+        this.targetNode.visible=false; this.active=false; this.fading=false;
+        if (isTouch) isMediaBusy = false;
       }
-  } }
+    }
+  }
 });
 
 /* ========== dog (attention + позиционный звук) ========== */
 AFRAME.registerComponent('attention-dog',{
-  schema:{ radius:{default:1.0}, hysteresis:{default:0.20}, lifeMs:{default:6000}, fadeMs:{default:600} },
-  init(){ this.armed=true; this.playing=false; this.dogNode=null; this.soundEl=null; this.spawnTime=0; this.fading=false; this.fadeStart=0;
+  schema:{ lifeMs:{default:6000}, fadeMs:{default:600} },
+  init(){
+    this.armed=true;
+    this.playing=false;
+    this.dogNode=null;
+    this.soundEl=null;
+    this.spawnTime=0;
+    this.fading=false;
+    this.fadeStart=0;
     whenModelReady(root=>{
       this.dogNode=findNodeByName(root,'dog'); if(!this.dogNode){ console.warn('dog node not found'); return; }
       this.dogNode.visible=false; this.dogNode.scale.setScalar(0);
@@ -548,32 +567,30 @@ AFRAME.registerComponent('attention-dog',{
       s.setAttribute('sound','src:#dogAudio; positional:true; refDistance:2; maxDistance:12; rolloffFactor:1');
       this.soundEl=s; streetEntity.sceneEl.appendChild(s);
     });
+    this.el.addEventListener('player-enter', () => {
+        if (this.armed && !this.playing) this.trigger();
+    });
+    this.el.addEventListener('player-leave', () => {
+        if (!this.playing) this.armed = true;
+    });
   },
   tick(){
-    if(!this.dogNode) return;
-    const m=(isTouch?rig:camEl).object3D.getWorldPosition(new THREE.Vector3());
-    const t=this.el.object3D.getWorldPosition(new THREE.Vector3());
-    const d=Math.hypot(m.x-t.x, m.z-t.z);
-
-    if (this.armed && d<=this.data.radius && !this.playing){ this.trigger(); this.armed=false; }
-    else if (!this.armed && d>(this.data.radius+this.data.hysteresis) && !this.playing){ this.armed=true; }
-
-    if (this.playing){
-      const now=this.el.sceneEl.time;
-      if (!this.fading && (now - this.spawnTime) >= this.data.lifeMs){ this.fading=true; this.fadeStart=now; }
-      if (this.fading){
-        const t=(now - this.fadeStart)/this.data.fadeMs; const k=Math.min(1,Math.max(0,t)); const s=1-(k*k*(3-2*k));
-        this.dogNode.scale.setScalar(Math.max(0,s));
-        if (k>=1){
-          this.dogNode.visible=false; this.playing=false; this.fading=false;
-          if (isTouch) isMediaBusy = false;
-        }
+    if(!this.dogNode || !this.playing) return;
+    const now=this.el.sceneEl.time;
+    if (!this.fading && (now - this.spawnTime) >= this.data.lifeMs){ this.fading=true; this.fadeStart=now; }
+    if (this.fading){
+      const t=(now - this.fadeStart)/this.data.fadeMs; const k=Math.min(1,Math.max(0,t)); const s=1-(k*k*(3-2*k));
+      this.dogNode.scale.setScalar(Math.max(0,s));
+      if (k>=1){
+        this.dogNode.visible=false; this.playing=false; this.fading=false;
+        if (isTouch) isMediaBusy = false;
       }
     }
   },
   trigger(){
     if (isTouch && isMediaBusy) return;
     if (isTouch) isMediaBusy = true;
+    this.armed = false;
     resumeSceneAudioContext();
     this.playing=true; this.spawnTime=this.el.sceneEl.time; this.fading=false;
     this.dogNode.visible=true; this.dogNode.scale.setScalar(1);
@@ -590,20 +607,21 @@ AFRAME.registerComponent('attention-dog',{
 
 /* ========== Плейны: iOS — видео без звука, desktop — как было ========== */
 AFRAME.registerComponent('plane-video-once',{
-  schema:{ nodeName:{default:''}, videoSrc:{default:''}, audio:{default:''}, radius:{default:2.5}, hysteresis:{default:0.10} },
+  schema:{ nodeName:{default:''}, videoSrc:{default:''}, audio:{default:''}, hysteresis:{default:0.10} },
   init(){
-    this.node=null; this.ready=false; this.playing=false; this.waitExit=false;
-    this.video=null; this.tex=null;
+    this.node=null;
+    this.ready=false;
+    this.playing=false;
+    this.waitExit=false;
+    this.video=null;
+    this.tex=null;
     whenModelReady(root=>{ this.node=findNodeByName(root, this.data.nodeName); if(!this.node) return; this.node.visible=false; this.ready=true; });
-  },
-  tick(){
-    if(!this.ready||!this.node) return;
-    if (isTouch && isMediaBusy) return;
-    const m=(isTouch?rig:camEl).object3D.getWorldPosition(new THREE.Vector3());
-    const t=this.node.getWorldPosition(new THREE.Vector3());
-    const d=Math.hypot(m.x-t.x, m.z-t.z);
-    if(!this.playing && !this.waitExit && d<=this.data.radius){ this.startVideo(); }
-    else if (this.waitExit && d>(this.data.radius+this.data.hysteresis)){ this.waitExit=false; }
+    this.el.addEventListener('player-enter', () => {
+        if(!this.playing && !this.waitExit) this.startVideo();
+    });
+    this.el.addEventListener('player-leave', () => {
+        if (this.waitExit) this.waitExit = false;
+    });
   },
   async startVideo(){
     if (!userMediaUnlocked){ const retry=()=>{ window.removeEventListener('touchstart', retry); this.startVideo(); }; window.addEventListener('touchstart', retry, {once:true}); return; }
@@ -736,13 +754,56 @@ AFRAME.registerComponent('clamp-rect',{
 });
 document.querySelector('a-scene').setAttribute('clamp-rect','minX:-25; maxX:25; minZ:-10; maxZ:10');
 
+/* ========== Proximity Checker ========== */
+AFRAME.registerComponent('proximity-checker', {
+    schema: {
+        interval: { default: 10 } // Check every 10 ticks
+    },
+    init: function () {
+        this.triggers = [];
+        this.tickCounter = 0;
+        // The querySelectorAll needs to run after the scene is loaded.
+        // We'll populate it on the first tick.
+    },
+    tick: function () {
+        this.tickCounter++;
+        if (this.tickCounter % this.data.interval !== 0) return;
+
+        if (this.triggers.length === 0) {
+            // First time, or if new triggers are added.
+            const triggerEls = Array.from(this.el.sceneEl.querySelectorAll('.triggerable'));
+            this.triggers = triggerEls.map(el => ({
+                el: el,
+                radius: parseFloat(el.dataset.radius) || 2.0, // Default radius
+                inZone: false
+            }));
+        }
+
+        const playerPos = this.el.object3D.getWorldPosition(new THREE.Vector3());
+
+        for (const trigger of this.triggers) {
+            const triggerPos = trigger.el.object3D.getWorldPosition(new THREE.Vector3());
+            const distance = playerPos.distanceTo(triggerPos);
+            const isInZoneNow = distance <= trigger.radius;
+
+            if (isInZoneNow && !trigger.inZone) {
+                trigger.inZone = true;
+                const targetId = trigger.el.dataset.targetId;
+                const targetEl = targetId ? document.getElementById(targetId) : trigger.el;
+                if (targetEl) targetEl.emit('player-enter');
+            } else if (!isInZoneNow && trigger.inZone) {
+                trigger.inZone = false;
+                const targetId = trigger.el.dataset.targetId;
+                const targetEl = targetId ? document.getElementById(targetId) : trigger.el;
+                if (targetEl) targetEl.emit('player-leave');
+            }
+        }
+    }
+});
+
 /* ========== moving object ========== */
 AFRAME.registerComponent('moving-object-logic', {
-    schema: {
-        triggerPosition: { type: 'vec3', default: { x: -2.862, y: 1.6, z: 3.478 } },
-        radius: { default: 1.0 }
-    },
-
+    schema: {},
     init: function () {
         this.triggered = false;
         this.mixer = null;
@@ -756,6 +817,9 @@ AFRAME.registerComponent('moving-object-logic', {
         this.speed = 1;
         this.targetIndex = -1;
 
+        this.el.object3D.position.copy(this.spawnPoint);
+        this.el.setAttribute('visible', false);
+
         this.el.addEventListener('model-loaded', (e) => {
             try {
                 const model = e.detail.model;
@@ -768,27 +832,23 @@ AFRAME.registerComponent('moving-object-logic', {
                 console.error('Error setting up animation mixer:', err);
             }
         }, { once: true });
-    },
 
+        this.el.addEventListener('player-enter', () => {
+            if (!this.triggered) {
+                this.triggered = true;
+                this.el.setAttribute('visible', true);
+                this.targetIndex = 0;
+            }
+        });
+    },
     tick: function (time, deltaTime) {
         if (this.mixer) {
             this.mixer.update(deltaTime / 1000);
         }
-
-        if (!this.triggered) {
-            const playerPos = (isTouch ? rig : camEl).object3D.getWorldPosition(new THREE.Vector3());
-            const distance = playerPos.distanceTo(this.data.triggerPosition);
-            if (distance <= this.data.radius) {
-                this.triggered = true;
-                this.el.object3D.position.copy(this.spawnPoint);
-                this.targetIndex = 0;
-            }
-            return;
+        if (this.triggered) {
+            this.move(deltaTime);
         }
-
-        this.move(deltaTime);
     },
-
     move: function (deltaTime) {
         if (this.targetIndex === -1) return;
 
@@ -817,9 +877,13 @@ AFRAME.registerComponent('trigger-director',{
       // скрываем, что появляется по триггерам
       ['dog','gyros','sunset2','sunset3','waves'].forEach(nm=>{ const n=findNodeByName(root,nm); if(n){ n.visible=false; } });
 
-      const makeAtNode=(node, klass, comp, value)=>{
+      const makeAtNode=(node, klass, comp, value, radius)=>{
         const wp=new THREE.Vector3(); node.getWorldPosition(wp);
         const e=document.createElement('a-entity'); e.classList.add(klass);
+        if (radius) {
+            e.classList.add('triggerable');
+            e.dataset.radius = radius;
+        }
         e.setAttribute('position',`${wp.x} ${wp.y} ${wp.z}`); if(comp) e.setAttribute(comp, value); scene.appendChild(e); return e;
       };
 
@@ -833,27 +897,29 @@ AFRAME.registerComponent('trigger-director',{
       popups.forEach(p => {
         const node = findNodeByName(root, p.name);
         if (node) {
-          const e = makeAtNode(node, 'trigger-popup', 'popup-video-hud', `radius:${p.radius}; loops:${defLoops}; hysteresis:0.2; side:${p.side}; src:${p.src}; audio:${p.name}`);
+          const e = makeAtNode(node, 'trigger-popup', 'popup-video-hud', `loops:${defLoops}; hysteresis:0.2; side:${p.side}; src:${p.src}; audio:${p.name}`, p.radius);
           e.setAttribute('sound', `src:#${p.audioId}; positional:false`);
         }
       });
 
       const taverna=findNodeByName(root,'taverna');
-      if (taverna) makeAtNode(taverna,'trigger-reveal','reveal-node-rot-fade','targetName:gyros; radius:2.0; hysteresis:0.2; spinDegPerSec:60; lifeMs:15000; fadeMs:800; soundId:gyrosAudio');
+      if (taverna) makeAtNode(taverna,'trigger-reveal','reveal-node-rot-fade','targetName:gyros; spinDegPerSec:60; lifeMs:15000; fadeMs:800; soundId:gyrosAudio', 2.0);
 
       const attention=findNodeByName(root,'attention');
-      if (attention) makeAtNode(attention,'trigger-reveal','attention-dog','radius:1.0; hysteresis:0.2; lifeMs:6000; fadeMs:600');
+      if (attention) makeAtNode(attention,'trigger-reveal','attention-dog','lifeMs:6000; fadeMs:600', 1.0);
 
       ['sunset2','sunset3','waves'].forEach(name=>{
         const n=findNodeByName(root,name);
         if (n){
-          const e=makeAtNode(n,'trigger-plane', 'plane-video-once',`nodeName:${name}; videoSrc:assets/video/${name}.mp4; audio:${name}; radius:2.5; hysteresis:0.1`);
+          const e=makeAtNode(n,'trigger-plane', 'plane-video-once',`nodeName:${name}; videoSrc:assets/video/${name}.mp4; audio:${name}; hysteresis:0.1`, 2.5);
           e.setAttribute('sound', `src:#${name}Audio; positional:true`);
         }
       });
 
       const movingObjectRadarMarker = document.createElement('a-entity');
-      movingObjectRadarMarker.classList.add('trigger-moving');
+      movingObjectRadarMarker.classList.add('trigger-moving', 'triggerable');
+      movingObjectRadarMarker.dataset.radius = 1.0;
+      movingObjectRadarMarker.dataset.targetId = 'moving-object';
       movingObjectRadarMarker.setAttribute('position', '-2.862 1.6 3.478');
       scene.appendChild(movingObjectRadarMarker);
     });


### PR DESCRIPTION
This commit resolves a critical, persistent bug that caused the application to crash on mobile devices when new trigger-based features were added.

The root cause was determined to be a performance bottleneck caused by multiple components independently calculating player distance in their `tick` functions. This was not scalable on resource-constrained mobile devices.

This commit refactors the entire trigger system to a centralized, event-driven architecture:
1. A new `proximity-checker` component is added to the player. It is the single source of truth for player position, checking distances to all triggerable entities on a throttled interval.
2. When the player enters or leaves a trigger's radius, this central component emits `player-enter` and `player-leave` events on the respective trigger entities.
3. All trigger components (`popup-video-hud`, `reveal-node-rot-fade`, `attention-dog`, `plane-video-once`, and the new `moving-object-logic`) have been refactored. Their `tick` functions for distance checking have been removed, and they now react to the events from the central checker.

This new architecture is significantly more performant, scalable, and robust. It fixes the mobile crash, resolves the `attention-dog` sound bug, and successfully implements the new moving object feature.