### PR TITLE
Fix: Adjust camera clipping for Android devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,15 @@ document.querySelector('a-scene').addEventListener('loaded', ()=>{
   if (isiOS()){
     try{ const r = document.querySelector('a-scene').renderer; r.setPixelRatio(1); r.antialias = false; }catch(_){}
   }
+  if (AFRAME.utils.device.isAndroid()){
+    const camEl = document.getElementById('player');
+    if (camEl) {
+      const camera = camEl.getAttribute('camera');
+      camera.far = 10000;
+      camera.near = 0.1;
+      camEl.setAttribute('camera', camera);
+    }
+  }
 });
 
 /* ========== размеры HUD (радар+попап) ========== */


### PR DESCRIPTION
This commit addresses a clipping issue on Android devices where the skybox and other geometry were being clipped.

The camera's `near` and `far` clipping planes have been adjusted specifically for Android to prevent this issue. The `far` plane is increased to 10000 to ensure the sky is visible, and the `near` plane is adjusted to 0.1 to improve depth buffer precision.

These changes are applied conditionally only on Android devices and do not affect desktop or iOS platforms.