### PR TITLE
Fix scrolling and sky rendering issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.jsdelivr.net/npm/nipplejs@0.10.1/dist/nipplejs.min.js"></script>
   <style>
     *{ -webkit-tap-highlight-color:transparent; }
-    html,body{ margin:0; height:100%; background:#000; overflow:hidden; }
+    html,body{ margin:0; height:100%; background:#000; }
     a-loading-screen{ display:none !important; }
     .a-enter-vr-button { display: none !important; }
 
@@ -239,7 +239,7 @@
     <audio id="wavesAudio"  src="assets/audio/waves.mp3"  preload="auto" crossorigin="anonymous"></audio>
   </a-assets>
 
-  <a-sky src="#skyTex" theta-length="180"></a-sky>
+  <a-entity geometry="primitive: sphere; radius: 5000; segmentsWidth: 64; segmentsHeight: 20" material="shader: flat; src: #skyTex; side: back; height: 2048; width: 2048" scale="-1 1 1"></a-entity>
 
   <a-entity light="type: ambient; intensity: 0.35"></a-entity>
   <a-entity light="type: directional; intensity: 0.7" position="2 4 2"></a-entity>


### PR DESCRIPTION
This commit addresses two issues:
1.  The 'About' page text was not scrollable. This was fixed by removing the `overflow: hidden;` property from the `html, body` CSS rule.
2.  The sky was not fully visible on Android devices. This was fixed by replacing the `<a-sky>` element with an `<a-entity>` that has a sphere geometry and a flat material, which is a more compatible way to render the skybox on all devices.