### PR TITLE
Fix sky rendering and 'About' panel issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,6 @@
       -webkit-backdrop-filter: blur(3px); backdrop-filter: blur(3px);
       transform: translateY(-100%);
       transition: transform 260ms ease;
-      overflow: hidden;
       font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       position: relative; /* Jules: Make this a containing block */
     }
@@ -151,8 +150,14 @@
 
     .about-right { display: flex; align-items: center; gap: 12px; }
 
+    .about-content p {
+      margin: 0 0 1em 0;
+      line-height: 1.5;
+    }
+
     @media (max-width: 768px) {
       .about-panel { height: var(--panel-height-mobile); }
+      .about-content { font-size: 14px; }
     }
   </style>
 </head>
@@ -239,7 +244,7 @@
     <audio id="wavesAudio"  src="assets/audio/waves.mp3"  preload="auto" crossorigin="anonymous"></audio>
   </a-assets>
 
-  <a-entity geometry="primitive: sphere; radius: 5000; segmentsWidth: 64; segmentsHeight: 20" material="shader: flat; src: #skyTex; side: back; height: 2048; width: 2048" scale="-1 1 1"></a-entity>
+  <a-entity id="sky" geometry="primitive: sphere; radius: 5000; segmentsWidth: 64; segmentsHeight: 20" material="shader: flat; src: #skyTex; side: back; height: 2048; width: 2048" scale="-1 1 1"></a-entity>
 
   <a-entity light="type: ambient; intensity: 0.35"></a-entity>
   <a-entity light="type: directional; intensity: 0.7" position="2 4 2"></a-entity>
@@ -1240,7 +1245,7 @@ in a place once unfamiliar, but now home.</p>`;
       // Fix sky texture not being power-of-two
       const scene = document.querySelector('a-scene');
       scene.addEventListener('loaded', function () {
-        const skyEl = document.querySelector('a-sky');
+        const skyEl = document.querySelector('#sky');
         const skyTex = document.getElementById('skyTex');
 
         const img = new Image();
@@ -1259,7 +1264,9 @@ in a place once unfamiliar, but now home.</p>`;
           const ctx = canvas.getContext('2d');
           ctx.drawImage(img, 0, 0, newW, newH);
 
-          skyEl.setAttribute('src', canvas.toDataURL());
+          if (skyEl) {
+            skyEl.setAttribute('material', 'src', canvas.toDataURL());
+          }
         }
         img.src = skyTex.src;
       });


### PR DESCRIPTION
This commit addresses several issues:
1.  The sky was not rendering correctly on some Android devices. This was fixed by replacing the `<a-sky>` element with an `<a-entity>` with a sphere geometry and updating the corresponding JavaScript to correctly apply the resized texture to the new entity.
2.  The 'About' panel was not scrollable due to `overflow: hidden` properties. These have been removed to enable scrolling.
3.  The font size in the 'About' panel on mobile devices was too large. A media query has been added to reduce the font size for better readability on smaller screens.