### PR TITLE
Fix sky rendering and 'About' panel text fit issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 
     @media (max-width: 768px) {
       .about-panel { height: var(--panel-height-mobile); }
-      .about-content { font-size: 14px; }
+      .about-content { font-size: 2.2vh; }
     }
   </style>
 </head>
@@ -215,7 +215,7 @@
 
 <a-scene
   embedded
-  renderer="colorManagement:true; physicallyCorrectLights:false; antialias:true; precision:mediump; powerPreference:high-performance; fullscreen: false"
+  renderer="colorManagement:true; physicallyCorrectLights:false; antialias:true; precision:mediump; powerPreference:high-performance; fullscreen: false; logarithmicDepthBuffer: false"
   loading-screen="enabled:false"
   device-orientation-permission-ui="enabled:false"
   vr-mode-ui="enabled:false"
@@ -244,7 +244,7 @@
     <audio id="wavesAudio"  src="assets/audio/waves.mp3"  preload="auto" crossorigin="anonymous"></audio>
   </a-assets>
 
-  <a-entity id="sky" geometry="primitive: sphere; radius: 5000; segmentsWidth: 64; segmentsHeight: 20; thetaLength: 180" material="shader: flat; src: #skyTex; side: back; height: 2048; width: 2048" rotation="90 0 0"></a-entity>
+  <a-entity id="sky" geometry="primitive: sphere; radius: 5000; segmentsWidth: 64; segmentsHeight: 20; thetaLength: 180" material="shader: flat; src: #skyTex; side: back; height: 2048; width: 2048"></a-entity>
 
   <a-entity light="type: ambient; intensity: 0.35"></a-entity>
   <a-entity light="type: directional; intensity: 0.7" position="2 4 2"></a-entity>


### PR DESCRIPTION
This commit addresses two final issues based on user feedback:

1.  **Sky Rendering on Android:** The sky was appearing "cut in half". This has been addressed by disabling the logarithmic depth buffer in the A-Frame renderer, which is a common solution for such rendering artifacts on mobile devices. The incorrect rotation was also removed from the sky entity.

2.  **'About' Panel Text Fit on Mobile:** The text in the 'About' panel was not fitting on the screen on mobile devices. This has been fixed by using viewport height units (`vh`) for the font size, which makes the text scale automatically to the screen height.